### PR TITLE
추가 사항: 잘못된 enum 양식으로 요청을 보냈을 경우, 사용 가능한 열거 타입을 전달

### DIFF
--- a/src/main/java/com/nhnacademy/sensor_type_mapping/domain/SensorStatus.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/domain/SensorStatus.java
@@ -1,5 +1,8 @@
 package com.nhnacademy.sensor_type_mapping.domain;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 /**
  * 센서의 상태를 나타내는 열거형(enum)입니다. <br>
  * 센서와 데이터 타입 간 매핑의 현재 상태를 구분하는 데 사용됩니다.
@@ -26,5 +29,16 @@ public enum SensorStatus {
     /**
      * 매핑이 폐기되었거나 더 이상 사용되지 않는 상태입니다.
      */
-    ABANDONED
+    ABANDONED;
+
+    /**
+     * enum의 모든 타입을 담은 문자열입니다.
+     */
+    public static final String VALID_VALUES_STRING;
+
+    static {
+        VALID_VALUES_STRING = Arrays.stream(SensorStatus.values())
+                .map(Enum::name)
+                .collect(Collectors.joining(", "));
+    }
 }

--- a/src/main/java/com/nhnacademy/sensor_type_mapping/service/impl/SensorDataMappingServiceImpl.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/service/impl/SensorDataMappingServiceImpl.java
@@ -171,7 +171,10 @@ public class SensorDataMappingServiceImpl implements SensorDataMappingService {
                 );
             }
         } catch (IllegalArgumentException e) {
-            throw new BadRequestException("잘못된 요청");
+            throw new BadRequestException(
+                    "사용 가능한 값: [%s]"
+                            .formatted(SensorStatus.VALID_VALUES_STRING)
+            );
         }
         return sensorDataMappingRepository.findAllAiResponsesBySensorStatuses(sensorStatuses);
     }


### PR DESCRIPTION
- 잘못된 enum 타입을 입력 했을 시, API가 지원하는 enum 타입을 알려줌으로서
사용자에게 도움이 되도록 기능 보강