### PR TITLE
Feature/threshold find limit

### DIFF
--- a/src/main/java/com/nhnacademy/sensor/service/impl/SensorServiceImpl.java
+++ b/src/main/java/com/nhnacademy/sensor/service/impl/SensorServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Set;
 
 @Service
+@Transactional
 public class SensorServiceImpl implements SensorService {
 
     private final SensorRepository sensorRepository;

--- a/src/main/java/com/nhnacademy/sensor_type_mapping/controller/SensorDataMappingController.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/controller/SensorDataMappingController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.Set;
 
-@Slf4j
 @RestController
 @RequestMapping("/sensor-data-mappings")
 public class SensorDataMappingController {

--- a/src/main/java/com/nhnacademy/sensor_type_mapping/service/impl/SensorDataMappingServiceImpl.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/service/impl/SensorDataMappingServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 @Service
+@Transactional
 public class SensorDataMappingServiceImpl implements SensorDataMappingService {
 
     private final SensorService sensorService;

--- a/src/main/java/com/nhnacademy/threshold/controller/ThresholdHistoryController.java
+++ b/src/main/java/com/nhnacademy/threshold/controller/ThresholdHistoryController.java
@@ -2,6 +2,7 @@ package com.nhnacademy.threshold.controller;
 
 import com.nhnacademy.threshold.dto.RuleEngineResponse;
 import com.nhnacademy.threshold.dto.ThresholdHistoryInfo;
+import com.nhnacademy.threshold.dto.ThresholdInfoResponse;
 import com.nhnacademy.threshold.service.ThresholdHistoryService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -41,9 +42,30 @@ public class ThresholdHistoryController {
      * AI 쪽에서 요청을 보내고, 대신 분석 완료된 상태만
      * 1시 30분
      */
-    /*public ResponseEntity<Void> getList() {
+    public ResponseEntity<List<RuleEngineResponse>> getList() {
+        return ResponseEntity
+                .ok(null);
+    }
 
-    }*/
+    @GetMapping("/gateway-id/{gateway-id}/sensor-id/{sensor-id}/type-en-name/{type-en-name}/limit/{limit}")
+    public ResponseEntity<List<ThresholdInfoResponse>> getList2(
+            @PathVariable("gateway-id") Long gatewayId,
+            @PathVariable("sensor-id") String sensorId,
+            @PathVariable("type-en-name") String typeEnName,
+            @PathVariable("limit") Integer limit
+    ) {
+        log.info("gatewayId: {}", gatewayId);
+        log.info("sensorId: {}", sensorId);
+        log.info("typeEnName: {}", typeEnName);
+        log.info("limit: {}", limit);
+        return ResponseEntity
+                .ok(
+                        thresholdHistoryService.getLatestThresholdInfoBySensorDataAndLimit(
+                                gatewayId, sensorId,
+                                typeEnName, limit
+                        )
+                );
+    }
 
     @PostMapping
     public ResponseEntity<Void> registerThresholdHistory(

--- a/src/main/java/com/nhnacademy/threshold/dto/AvgRangeInfo.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/AvgRangeInfo.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
 public final class AvgRangeInfo {
 
     @NotNull(message = "평균 임계치의 최소값을 전달받지 못했습니다.")

--- a/src/main/java/com/nhnacademy/threshold/dto/DiffInfo.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/DiffInfo.java
@@ -3,10 +3,8 @@ package com.nhnacademy.threshold.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
 public final class DiffInfo {
 
     private final Double diffMin;

--- a/src/main/java/com/nhnacademy/threshold/dto/MaxRangeInfo.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/MaxRangeInfo.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
 public final class MaxRangeInfo {
 
     @NotNull(message = "최고 임계치의 최소값을 전달받지 못했습니다.")

--- a/src/main/java/com/nhnacademy/threshold/dto/MinRangeInfo.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/MinRangeInfo.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
 public final class MinRangeInfo {
 
     @NotNull(message = "최저 임계치의 최소값을 전달받지 못했습니다.")

--- a/src/main/java/com/nhnacademy/threshold/dto/ThresholdHistoryInfo.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/ThresholdHistoryInfo.java
@@ -8,11 +8,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
-import lombok.ToString;
 
 /// TODO: Valid message 양식을 다듬기
 @Getter
-@ToString
 public final class ThresholdHistoryInfo {
 
     @Valid

--- a/src/main/java/com/nhnacademy/threshold/dto/ThresholdHistoryInfoResponse.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/ThresholdHistoryInfoResponse.java
@@ -1,9 +1,0 @@
-package com.nhnacademy.threshold.dto;
-
-import lombok.Value;
-
-@Value
-public class ThresholdHistoryInfoResponse {
-
-
-}

--- a/src/main/java/com/nhnacademy/threshold/dto/ThresholdInfo.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/ThresholdInfo.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
 public final class ThresholdInfo {
 
     @NotNull(message = "분석된 최저 임계치 값을 전달받지 못했습니다.")

--- a/src/main/java/com/nhnacademy/threshold/dto/ThresholdInfoResponse.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/ThresholdInfoResponse.java
@@ -1,0 +1,21 @@
+package com.nhnacademy.threshold.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public final class ThresholdInfoResponse {
+
+    private final Double thresholdMin;
+
+    private final Double thresholdMax;
+
+    private final Double thresholdAvg;
+
+    @QueryProjection
+    public ThresholdInfoResponse(Double thresholdMin, Double thresholdMax, Double thresholdAvg) {
+        this.thresholdMin = thresholdMin;
+        this.thresholdMax = thresholdMax;
+        this.thresholdAvg = thresholdAvg;
+    }
+}

--- a/src/main/java/com/nhnacademy/threshold/repository/CustomThresholdHistoryRepository.java
+++ b/src/main/java/com/nhnacademy/threshold/repository/CustomThresholdHistoryRepository.java
@@ -1,10 +1,16 @@
 package com.nhnacademy.threshold.repository;
 
 import com.nhnacademy.threshold.dto.RuleEngineResponse;
+import com.nhnacademy.threshold.dto.ThresholdInfoResponse;
 
 import java.util.List;
 
 public interface CustomThresholdHistoryRepository {
 
     List<RuleEngineResponse> findLatestThresholdSummariesByGatewayId(long gatewayId);
+
+    List<ThresholdInfoResponse> findLatestThresholdInfoBySensorDataAndLimit(
+            long gatewayId, String sensorId,
+            String typeEnName, int limit
+    );
 }

--- a/src/main/java/com/nhnacademy/threshold/service/ThresholdHistoryService.java
+++ b/src/main/java/com/nhnacademy/threshold/service/ThresholdHistoryService.java
@@ -3,6 +3,7 @@ package com.nhnacademy.threshold.service;
 import com.nhnacademy.threshold.domain.ThresholdHistory;
 import com.nhnacademy.threshold.dto.RuleEngineResponse;
 import com.nhnacademy.threshold.dto.ThresholdHistoryInfo;
+import com.nhnacademy.threshold.dto.ThresholdInfoResponse;
 
 import java.util.List;
 
@@ -13,4 +14,9 @@ public interface ThresholdHistoryService {
     ThresholdHistory getThresholdHistoryByThresholdHistoryNo(long thresholdHistoryNo);
 
     List<RuleEngineResponse> getLatestThresholdSummariesByGatewayId(long gatewayId);
+
+    List<ThresholdInfoResponse> getLatestThresholdInfoBySensorDataAndLimit(
+            long gatewayId, String sensorId,
+            String typeEnName, int limit
+    );
 }

--- a/src/main/java/com/nhnacademy/threshold/service/impl/ThresholdHistoryServiceImpl.java
+++ b/src/main/java/com/nhnacademy/threshold/service/impl/ThresholdHistoryServiceImpl.java
@@ -10,10 +10,12 @@ import com.nhnacademy.threshold.dto.ThresholdHistoryInfo;
 import com.nhnacademy.threshold.repository.ThresholdHistoryRepository;
 import com.nhnacademy.threshold.service.ThresholdHistoryService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional
 public class ThresholdHistoryServiceImpl implements ThresholdHistoryService {
 
     private final ThresholdHistoryRepository thresholdHistoryRepository;

--- a/src/main/java/com/nhnacademy/threshold/service/impl/ThresholdHistoryServiceImpl.java
+++ b/src/main/java/com/nhnacademy/threshold/service/impl/ThresholdHistoryServiceImpl.java
@@ -7,6 +7,7 @@ import com.nhnacademy.sensor_type_mapping.repository.SensorDataMappingRepository
 import com.nhnacademy.threshold.domain.ThresholdHistory;
 import com.nhnacademy.threshold.dto.RuleEngineResponse;
 import com.nhnacademy.threshold.dto.ThresholdHistoryInfo;
+import com.nhnacademy.threshold.dto.ThresholdInfoResponse;
 import com.nhnacademy.threshold.repository.ThresholdHistoryRepository;
 import com.nhnacademy.threshold.service.ThresholdHistoryService;
 import org.springframework.stereotype.Service;
@@ -82,5 +83,16 @@ public class ThresholdHistoryServiceImpl implements ThresholdHistoryService {
     @Override
     public List<RuleEngineResponse> getLatestThresholdSummariesByGatewayId(long gatewayId) {
         return thresholdHistoryRepository.findLatestThresholdSummariesByGatewayId(gatewayId);
+    }
+
+    @Override
+    public List<ThresholdInfoResponse> getLatestThresholdInfoBySensorDataAndLimit(
+            long gatewayId, String sensorId,
+            String typeEnName, int limit
+    ) {
+        return thresholdHistoryRepository.findLatestThresholdInfoBySensorDataAndLimit(
+                gatewayId, sensorId,
+                typeEnName, limit
+        );
     }
 }

--- a/src/main/java/com/nhnacademy/type/domain/DataType.java
+++ b/src/main/java/com/nhnacademy/type/domain/DataType.java
@@ -49,7 +49,6 @@ public class DataType {
         this.dataTypeKrName = dataTypeKrName;
     }
 
-    /// TODO: 한글명은 구글 번역기 라이브러리를 활용해 즉시, 반영한다.
     /**
      * <b>정적 팩토리 메서드입니다.</b>
      * <hr>

--- a/src/main/java/com/nhnacademy/type/service/impl/DataTypeServiceImpl.java
+++ b/src/main/java/com/nhnacademy/type/service/impl/DataTypeServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class DataTypeServiceImpl implements DataTypeService {
 
     private final DataTypeRepository dataTypeRepository;


### PR DESCRIPTION
- 특정 센서(SensorDataMapping)에 해당하는 분석된 데이터들을 등록된 시간을 기준으로
내림차순으로 지정된 수 만큼 가져오는 기능 추가

```sql
SELECT th.threshold_min, th.threshold_max, th.threshold_avg
FROM threshold_historys AS th
	INNER JOIN sensor_data_mappings AS sdm
    ON th.sensor_data_no = sdm.sensor_data_no
    INNER JOIN sensors AS s
    ON sdm.sensor_no = s.sensor_no
    INNER JOIN data_types AS dt
    ON sdm.type_en_name = dt.type_en_name
WHERE s.gateway_id = ?
	AND s.sensor_id = ?
    AND dt.type_en_name = ?
ORDER BY th.calculated_at DESC
LIMIT ?
```
