### PR TITLE
변경 사항: AI 서비스에서 필요한 임계치 범위 지정할 수 있는 데이터 구성을 추가

### DIFF
--- a/src/main/java/com/nhnacademy/threshold/dto/ThresholdBoundResponse.java
+++ b/src/main/java/com/nhnacademy/threshold/dto/ThresholdBoundResponse.java
@@ -10,16 +10,22 @@ public final class ThresholdBoundResponse {
 
     private final Double minRangeMin;
 
+    private final Double minRangeMax;
+
+    private final Double maxRangeMin;
+
     private final Double maxRangeMax;
 
     @QueryProjection
     public ThresholdBoundResponse(
             String typeEnName,
-            Double minRangeMin,
-            Double maxRangeMax
+            Double minRangeMin, Double minRangeMax,
+            Double maxRangeMin, Double maxRangeMax
     ) {
         this.typeEnName = typeEnName;
         this.minRangeMin = minRangeMin;
+        this.minRangeMax = minRangeMax;
+        this.maxRangeMin = maxRangeMin;
         this.maxRangeMax = maxRangeMax;
     }
 }

--- a/src/main/java/com/nhnacademy/threshold/repository/impl/CustomThresholdHistoryRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/threshold/repository/impl/CustomThresholdHistoryRepositoryImpl.java
@@ -90,6 +90,8 @@ public class CustomThresholdHistoryRepositoryImpl extends QuerydslRepositorySupp
                         new QThresholdBoundResponse(
                                 qDataType.dataTypeEnName,
                                 qThresholdHistory.minRangeMin,
+                                qThresholdHistory.minRangeMax,
+                                qThresholdHistory.maxRangeMin,
                                 qThresholdHistory.maxRangeMax
                         )
                 )
@@ -120,6 +122,8 @@ public class CustomThresholdHistoryRepositoryImpl extends QuerydslRepositorySupp
                         new QThresholdBoundResponse(
                                 qDataType.dataTypeEnName,
                                 qThresholdHistory.minRangeMin,
+                                qThresholdHistory.minRangeMax,
+                                qThresholdHistory.maxRangeMin,
                                 qThresholdHistory.maxRangeMax
                         )
                 )


### PR DESCRIPTION
## 목차

1. 특정 센서에 대해, 연결된 모든 데이터 타입별 최신 임계값(`Threshold`) 목록을 조회하는 기능을 수정
2. 특정 센서-데이터 타입 매핑(`SensorDataMapping`)에 대해 최신 임계값(`Threshold`) 하나를 조회하는 기능을 수정

---

### 1. 특정 센서에 대해, 연결된 모든 데이터 타입별 최신 임계값(`Threshold`) 목록을 조회하는 구성을 변경

```http
GET http://team1-sensor-service:10238/threshold-histories/gateway-id/{gateway-id}/sensor-id/{sensor-id}
```
- 위의 형식으로 **HTTP GET** 요청 시, 아래와 같은 구조로 데이터를 반환합니다.

```json
[
  {
    "type_en_name": "illumination",
    "min_range_min": 64.55,
    "min_range_max": 64.36,
    "max_range_min": 65.65,
    "max_range_max": 65.83
  },
  {
    "type_en_name": "infrared_and_visible",
    "min_range_min": 44.77,
    "min_range_max": 44.71,
    "max_range_min": 45.36,
    "max_range_max": 45.33
  },
  {
    "type_en_name": "infrared",
    "min_range_min": 7.0,
    "min_range_max": 7.0,
    "max_range_min": 7.0,
    "max_range_max": 7.0
  },
  {
    "type_en_name": "activity",
    "min_range_min": -2.4,
    "min_range_max": -3.59,
    "max_range_min": 13.69,
    "max_range_max": 15.34
  },
  {
    "type_en_name": "temperature",
    "min_range_min": 25.2,
    "min_range_max": 25.17,
    "max_range_min": 25.24,
    "max_range_max": 25.2
  },
  {
    "type_en_name": "humidity",
    "min_range_min": 49.5,
    "min_range_max": 49.5,
    "max_range_min": 49.5,
    "max_range_max": 49.5
  },
  {
    "type_en_name": "co2",
    "min_range_min": 1065.79,
    "min_range_max": 1093.21,
    "max_range_min": 1125.91,
    "max_range_max": 1112.01
  },
  {
    "type_en_name": "tvoc",
    "min_range_min": 102.86,
    "min_range_max": 105.47,
    "max_range_min": 112.98,
    "max_range_max": 108.8
  },
  {
    "type_en_name": "pressure",
    "min_range_min": 995.3,
    "min_range_max": 995.16,
    "max_range_min": 995.2,
    "max_range_max": 995.3
  }
]
```

---

### 2. 특정 센서-데이터 타입 매핑(`SensorDataMapping`)에 대해 최신 임계값(`Threshold`) 하나를 조회하는 구성을 변경

```http
GET http://team1-sensor-service:10238/threshold-histories/gateway-id/{gateway-id}/sensor-id/{sensor-id}/type-en-name/{type-en-name}
```

- 위의 형식으로 **HTTP GET** 요청 시, 아래와 같은 구조로 데이터를 반환합니다.

```json
{
  "type_en_name": "illumination",
  "min_range_min": 64.55,
  "min_range_max": 64.36,
  "max_range_min": 65.65,
  "max_range_max": 65.83
}
```