### PR TITLE
변경 사항: `SensorDataMapping` 영역에 새로운 데이터를 저장 시, `Gateway-Service`를 통해서 sensorCount를 갱신하는 로직 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,11 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-            <!-- 불필요한 로드 밸런싱 제거, 게이트웨이에게 책임을 넘긴다. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.cloud</groupId>
-                    <artifactId>spring-cloud-starter-loadbalancer</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
 
         <!-- ======================================================================================================= -->

--- a/src/main/java/com/nhnacademy/SensorServiceApplication.java
+++ b/src/main/java/com/nhnacademy/SensorServiceApplication.java
@@ -3,7 +3,9 @@ package com.nhnacademy;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @EnableDiscoveryClient
 @SpringBootApplication
 public class SensorServiceApplication {

--- a/src/main/java/com/nhnacademy/common/advice/CommonAdvice.java
+++ b/src/main/java/com/nhnacademy/common/advice/CommonAdvice.java
@@ -38,7 +38,7 @@ public class CommonAdvice {
         e.getBindingResult().getAllErrors().forEach(error -> {
             if (error instanceof FieldError fieldError) {
                 errors.add(
-                        "{\"field\":\"%s\", \"rejected_value\":\"%s\", \"message\":\"%s\"}".formatted(
+                        "{'field':'%s', 'rejected_value':'%s', 'message':'%s'}".formatted(
                                 namingBase != null
                                         ? namingBase.translate(fieldError.getField())
                                         : fieldError.getField(),

--- a/src/main/java/com/nhnacademy/infrastructure/adapter/GatewayServiceAdapter.java
+++ b/src/main/java/com/nhnacademy/infrastructure/adapter/GatewayServiceAdapter.java
@@ -1,0 +1,16 @@
+package com.nhnacademy.infrastructure.adapter;
+
+import com.nhnacademy.infrastructure.dto.GatewayCountUpdateRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "gateway-service")
+public interface GatewayServiceAdapter {
+
+    @PutMapping("/gateways/update-sensor-count")
+    ResponseEntity<Void> updateGatewaySensorCount(
+            @RequestBody GatewayCountUpdateRequest request
+    );
+}

--- a/src/main/java/com/nhnacademy/infrastructure/dto/GatewayCountUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/infrastructure/dto/GatewayCountUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.nhnacademy.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+
+@Getter
+public final class GatewayCountUpdateRequest {
+
+    @NotNull
+    private final Long gatewayId;
+
+    @NotNull
+    @PositiveOrZero
+    private final Integer sensorCount;
+
+    @JsonCreator
+    public GatewayCountUpdateRequest(
+            @JsonProperty("gateway_id") Long gatewayId,
+            @JsonProperty("sensor_count") Integer sensorCount
+    ) {
+        this.gatewayId = gatewayId;
+        this.sensorCount = sensorCount;
+    }
+}

--- a/src/main/java/com/nhnacademy/sensor_type_mapping/dto/SensorDataMappingWebResponse.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/dto/SensorDataMappingWebResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public final class SensorDataMappingWebResponse {
 
-    @JsonProperty("no")
+    @JsonProperty("sensor_data_no")
     private final Long sensorNo;
 
     @JsonProperty("gateway_id")

--- a/src/main/java/com/nhnacademy/sensor_type_mapping/repository/CustomSensorDataMappingRepository.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/repository/CustomSensorDataMappingRepository.java
@@ -52,4 +52,6 @@ public interface CustomSensorDataMappingRepository {
     List<SensorDataMappingAiResponse> findAllAiResponsesBySensorStatuses(List<SensorStatus> sensorStatuses);
 
     Set<SensorDataMappingIndexResponse> findAllSensorDataUniqueKeys();
+
+    int countByGatewayId(long gatewayId);
 }

--- a/src/main/java/com/nhnacademy/sensor_type_mapping/repository/impl/CustomSensorDataMappingRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/repository/impl/CustomSensorDataMappingRepositoryImpl.java
@@ -248,6 +248,17 @@ public class CustomSensorDataMappingRepositoryImpl extends QuerydslRepositorySup
         return uniqueSet;
     }
 
+    @Override
+    public int countByGatewayId(long gatewayId) {
+        Long count = queryFactory
+                .select(qSensorDataMapping.sensorDataNo.count())
+                .from(qSensorDataMapping)
+                .innerJoin(qSensorDataMapping.sensor, qSensor)
+                .where(qSensor.gatewayId.eq(gatewayId))
+                .fetchOne();
+        return count != null ? count.intValue() : 0;
+    }
+
     private BooleanBuilder getSearchStatuses(List<SensorStatus> sensorStatuses) {
         BooleanBuilder builder = new BooleanBuilder();
         for (SensorStatus sensorStatus : sensorStatuses) {

--- a/src/main/java/com/nhnacademy/sensor_type_mapping/service/impl/SensorDataMappingServiceImpl.java
+++ b/src/main/java/com/nhnacademy/sensor_type_mapping/service/impl/SensorDataMappingServiceImpl.java
@@ -2,6 +2,8 @@ package com.nhnacademy.sensor_type_mapping.service.impl;
 
 import com.nhnacademy.common.exception.http.extend.SensorDataMappingAlreadyExistsException;
 import com.nhnacademy.common.exception.http.extend.SensorDataMappingNotFoundException;
+import com.nhnacademy.infrastructure.adapter.GatewayServiceAdapter;
+import com.nhnacademy.infrastructure.dto.GatewayCountUpdateRequest;
 import com.nhnacademy.sensor.domain.Sensor;
 import com.nhnacademy.sensor.service.SensorService;
 import com.nhnacademy.sensor_type_mapping.domain.SensorDataMapping;
@@ -35,13 +37,17 @@ public class SensorDataMappingServiceImpl implements SensorDataMappingService {
 
     private final SensorDataMappingRepository sensorDataMappingRepository;
 
+    private final GatewayServiceAdapter gatewayServiceAdapter;
+
     public SensorDataMappingServiceImpl(
             SensorService sensorService, DataTypeService dataTypeService,
-            SensorDataMappingRepository sensorDataMappingRepository
+            SensorDataMappingRepository sensorDataMappingRepository,
+            GatewayServiceAdapter gatewayServiceAdapter
     ) {
         this.sensorService = sensorService;
         this.dataTypeService = dataTypeService;
         this.sensorDataMappingRepository = sensorDataMappingRepository;
+        this.gatewayServiceAdapter = gatewayServiceAdapter;
     }
 
     @Override
@@ -61,7 +67,6 @@ public class SensorDataMappingServiceImpl implements SensorDataMappingService {
                 ? sensorService.getReferenceSensor(request.getSensorInfo())
                 : sensorService.registerSensor(request.getSensorInfo());
 
-        /// TODO: 번역기 라이브러리 적용하기
         DataType dataType = dataTypeService.isExistsDataType(request.getDataTypeEnName())
                 ? dataTypeService.getReferenceDataType(request.getDataTypeEnName())
                 : dataTypeService.registerDataType(request.getDataTypeEnName(), request.getDataTypeEnName());
@@ -73,6 +78,13 @@ public class SensorDataMappingServiceImpl implements SensorDataMappingService {
                         SensorStatus.PENDING
                 );
         sensorDataMappingRepository.save(sensorDataMapping);
+
+        long gatewayId = sensor.getGatewayId();
+        GatewayCountUpdateRequest updateRequest = new GatewayCountUpdateRequest(
+                gatewayId,
+                sensorDataMappingRepository.countByGatewayId(gatewayId)
+        );
+        gatewayServiceAdapter.updateGatewaySensorCount(updateRequest);
     }
 
     @Override


### PR DESCRIPTION
## 목차

1. `SensorDataMapping`에 새로운 데이터를 저장할 때, 해당 데이터에 포함된 `gatewayId`에 대응하는 `gateways` 테이블의 `sensor_count` 값을 함께 갱신하는 로직을 추가합니다.

---

### 1. `SensorDataMapping`에 새로운 데이터를 저장 시, 그에 대응하는 `gateways` 테이블의 `gatewayId` 행에 해당하는 `sensor_count` 값을 갱신

- 이제 `gatewayId`에 속한 모든 센서들의 갯수를 조회할 수 있게 되었습니다.

```java
    private void registerSensorDataMapping(SensorDataMappingInfo request) {

        // SensorDataMaping save...

        long gatewayId = sensor.getGatewayId();
        GatewayCountUpdateRequest updateRequest = new GatewayCountUpdateRequest(
                gatewayId,
                sensorDataMappingRepository.countByGatewayId(gatewayId)
        );
        gatewayServiceAdapter.updateGatewaySensorCount(updateRequest);
    }
```